### PR TITLE
[OR-251] change deployment logic of l1 token contract

### DIFF
--- a/packages/contracts/deploy/015-L1TonToken.ts
+++ b/packages/contracts/deploy/015-L1TonToken.ts
@@ -2,15 +2,18 @@
 import { DeployFunction } from 'hardhat-deploy/dist/types'
 
 /* Imports: Internal */
-import { deployAndRegister } from '../src/deploy-utils'
+import { deployAndRegister, isHardhatNode } from '../src/deploy-utils'
 
 const deployFn: DeployFunction = async (hre) => {
-  await deployAndRegister({
-    hre,
-    name: 'L1TonToken',
-    contract: 'TON',
-    args: [],
-  })
+  // Only execute this step if we're on the hardhat chain ID.
+  if (await isHardhatNode(hre)) {
+    await deployAndRegister({
+      hre,
+      name: 'L1TonToken',
+      contract: 'TON',
+      args: [],
+    })
+  }
 }
 
 deployFn.tags = ['L1TonToken']


### PR DESCRIPTION
isHardhatNode flag에 따라 L1 토큰 컨트랙트 배포 유무를 결정하도록 변경하였습니다.

- L1 토큰 컨트랙트는 조건문에 따라 hardhat node를 사용할 때만 배포하도록 수정
- rinkeby나 mainet에서는 기존에 배포된 L1 TON contract를 사용