### PR TITLE
[OR-344] Fix nightly build for batch-submitter-service

### DIFF
--- a/.github/workflows/tokamak-public-nightly.yml
+++ b/.github/workflows/tokamak-public-nightly.yml
@@ -500,7 +500,9 @@ jobs:
 
       - name: Get version
         id: extractver
-        run: echo ::set-output name=VERSION::$(jq -r .version ./batch-submitter/package.json)
+        run: |
+          echo ::set-output name=VERSION::$(jq -r .version ./batch-submitter/package.json)
+          echo ::set-output name=GITSHA::"$GITHUB_SHA"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1


### PR DESCRIPTION
Github Action 은 확인하려면 머지해서 넣어야지만 가능해서 여러가지로 불편하네요.
이제 마지막 수정일듯합니다.