### PR TITLE
[OR-370] Fix ci target for tokamak-message-relayer

### DIFF
--- a/.github/workflows/tokamak-public-release.yml
+++ b/.github/workflows/tokamak-public-release.yml
@@ -177,7 +177,7 @@ jobs:
         with:
           context: .
           file: ./ops/docker/Dockerfile.packages
-          target: message-relayer
+          target: tokamak-message-relayer
           push: true
           tags: |
             onthertech/optimism.tokamak-message-relayer:${{ steps.extractver.outputs.RELEASE }}


### PR DESCRIPTION
실수했네요.
release시 tokamak-message-relayer가 실제로 만들어지지 않고 있었습니다.

버그 수정합니다~