### PR TITLE
OR-460 make initialization

### DIFF
--- a/packages/sdk/src/cross-chain-messenger.ts
+++ b/packages/sdk/src/cross-chain-messenger.ts
@@ -113,6 +113,11 @@ export class CrossChainMessenger {
   public bedrock: boolean
 
   /**
+   * Whether or not fast relayer is enabled.
+   */
+  public fastRelayer: boolean
+
+  /**
    * Parameters for the L2OutputOracle contract.
    */
   private _l2OutputOracleParameters: L2OutputOracleParameters
@@ -141,8 +146,10 @@ export class CrossChainMessenger {
     contracts?: DeepPartial<OEContractsLike>
     bridges?: BridgeAdapterData
     bedrock?: boolean
+    fastRelayer?: boolean
   }) {
     this.bedrock = opts.bedrock ?? false
+    this.fastRelayer = opts.fastRelayer
     this.l1SignerOrProvider = toSignerOrProvider(opts.l1SignerOrProvider)
     this.l2SignerOrProvider = toSignerOrProvider(opts.l2SignerOrProvider)
 

--- a/packages/tokamak/contracts/package.json
+++ b/packages/tokamak/contracts/package.json
@@ -30,7 +30,7 @@
     "dotenv": "^8.2.0"
   },
   "devDependencies": {
-    "@defi-wonderland/smock": "^2.3.4",
+    "@defi-wonderland/smock": "^2.0.2",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",

--- a/packages/tokamak/message-relayer/.env.example
+++ b/packages/tokamak/message-relayer/.env.example
@@ -1,5 +1,8 @@
 ## package test purpose
 
+# fast_relayer flag
+FAST_RELAYER=true
+
 # address of address manager
 MESSAGE_RELAYER__ADDRESS_MANAGER_ADDRESS='0x5FbDB2315678afecb367f032d93F642f64180aa3'
 

--- a/packages/tokamak/message-relayer/.env.example
+++ b/packages/tokamak/message-relayer/.env.example
@@ -1,11 +1,22 @@
+## package test purpose
+
+# address of address manager
+MESSAGE_RELAYER__ADDRESS_MANAGER_ADDRESS='0x5FbDB2315678afecb367f032d93F642f64180aa3'
+
+# address of l1 cross domain messenger fast
+L1_MESSENGER_FAST='0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f'
+
+# Base Contract URL
+URL=http://localhost:8080/addresses.json
+
 # URL pointing to an L1 RPC provider
-MESSAGE_RELAYER__L1_RPC_PROVIDER=
+MESSAGE_RELAYER__L1_RPC_PROVIDER=http://localhost:9545
 
 # URL pointing to an L2 RPC provider
-MESSAGE_RELAYER__L2_RPC_PROVIDER=
+MESSAGE_RELAYER__L2_RPC_PROVIDER=http://localhost:8545
 
 # Private key for a wallet with ETH on L1
-MESSAGE_RELAYER__L1_WALLET=
+MESSAGE_RELAYER__L1_WALLET='0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97'
 
 # Optional, L2 block height to start relaying messages from (default is 0)
 MESSAGE_RELAYER__FROM_L2_TRANSACTION_INDEX=

--- a/packages/tokamak/message-relayer/package.json
+++ b/packages/tokamak/message-relayer/package.json
@@ -35,7 +35,8 @@
     "@eth-optimism/contracts": "0.5.37",
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/sdk": "1.6.6",
-    "ethers": "^5.7.0"
+    "ethers": "^5.7.0",
+    "dotenv": "^8.2.0"
   },
   "devDependencies": {
     "@ethersproject/abstract-provider": "^5.7.0",

--- a/packages/tokamak/message-relayer/src/service.ts
+++ b/packages/tokamak/message-relayer/src/service.ts
@@ -153,6 +153,16 @@ export class MessageRelayerService extends BaseServiceV2<
   }
 
   protected async init(): Promise<void> {
+    // check options
+    this.logger.info('Initializing message relayer', {
+      fromL2TransactionIndex: this.options.fromL2TransactionIndex,
+      pollingInterval: this.options.pollingInterval,
+      filterPollingInterval: this.options.filterPollingInterval,
+      minBatchSize: this.options.minBatchSize,
+      maxWaitTimeS: this.options.maxWaitTimeS,
+      isFastRelayer: this.options.isFastRelayer,
+    })
+
     this.state.wallet = this.options.l1Wallet.connect(
       this.options.l1RpcProvider
     )
@@ -206,6 +216,7 @@ export class MessageRelayerService extends BaseServiceV2<
       depositConfirmationBlocks,
       l1BlockTimeSeconds,
       contracts,
+      fastRelayer: this.options.isFastRelayer,
     })
 
     this.state.highestCheckedL2Tx = this.options.fromL2TransactionIndex || 1

--- a/packages/tokamak/message-relayer/src/service.ts
+++ b/packages/tokamak/message-relayer/src/service.ts
@@ -17,6 +17,8 @@ import {
 } from '@eth-optimism/sdk'
 import { Provider } from '@ethersproject/abstract-provider'
 
+import 'dotenv/config'
+
 type MessageRelayerOptions = {
   l1RpcProvider: Provider
   l2RpcProvider: Provider
@@ -96,7 +98,7 @@ export class MessageRelayerService extends BaseServiceV2<
         isFastRelayer: {
           validator: validators.bool,
           desc: 'Whether the relayer support fast relay',
-          default: true,
+          default: false,
         },
         enableRelayerFilter: {
           validator: validators.bool,
@@ -161,6 +163,9 @@ export class MessageRelayerService extends BaseServiceV2<
   }
 
   protected async init(): Promise<void> {
+    if (process.env.FAST_RELAYER) {
+      this.options.isFastRelayer = true
+    }
     // check options
     this.logger.info('Initializing message relayer', {
       fromL2TransactionIndex: this.options.fromL2TransactionIndex,
@@ -230,7 +235,6 @@ export class MessageRelayerService extends BaseServiceV2<
       contracts,
       fastRelayer: this.options.isFastRelayer,
     })
-    console.log(this.state.messenger)
 
     this.state.highestCheckedL2Tx = this.options.fromL2TransactionIndex || 1
     this.state.highestKnownL2Tx =

--- a/packages/tokamak/message-relayer/src/service.ts
+++ b/packages/tokamak/message-relayer/src/service.ts
@@ -21,7 +21,17 @@ type MessageRelayerOptions = {
   l1RpcProvider: Provider
   l2RpcProvider: Provider
   l1Wallet: Signer
+  minBatchSize: number
+  maxWaitTimeS: number
+  isFastRelayer: boolean
+  enableRelayerFilter: boolean
+  filterEndpoint?: string
+  filterPollingInterval?: number
+  multiRelayLimit?: number
+  numConfirmations?: number
   fromL2TransactionIndex?: number
+  pollingInterval?: number
+  l1StartOffset?: number
   addressManagerAddress?: Address
 }
 
@@ -65,10 +75,60 @@ export class MessageRelayerService extends BaseServiceV2<
           desc: 'Wallet used to interact with L1.',
           secret: true,
         },
+        minBatchSize: {
+          validator: validators.num,
+          desc: 'Minimum size of the batch',
+          default: 2,
+        },
+        maxWaitTimeS: {
+          validator: validators.num,
+          desc: 'Maximum number of seconds to wait',
+          default: 60,
+        },
+        isFastRelayer: {
+          validator: validators.bool,
+          desc: 'Whether the relayer support fast relay',
+          default: true,
+        },
+        enableRelayerFilter: {
+          validator: validators.bool,
+          desc: 'Whether the relayer can use filter',
+          default: true,
+        },
+        filterEndpoint: {
+          validator: validators.str,
+          desc: 'The endpoint for getting filter',
+          default: '',
+        },
+        filterPollingInterval: {
+          validator: validators.num,
+          desc: 'The polling interval for getting filter',
+          default: 60000,
+        },
+        multiRelayLimit: {
+          validator: validators.num,
+          desc: 'The limit size of message buffer',
+          default: 10,
+        },
+        numConfirmations: {
+          validator: validators.num,
+          desc: 'The number of confirmations',
+          default: 1,
+        },
         fromL2TransactionIndex: {
           validator: validators.num,
           desc: 'Index of the first L2 transaction to start processing from.',
           default: 0,
+        },
+        pollingInterval: {
+          validator: validators.num,
+          desc: 'The polling interval of relayer service',
+          default: 1000,
+        },
+        l1StartOffset: {
+          validator: validators.num,
+          desc: 'The starting offset of the L1 block',
+          default: 1,
         },
         addressManagerAddress: {
           validator: validators.str,
@@ -100,6 +160,7 @@ export class MessageRelayerService extends BaseServiceV2<
     let contracts = {}
 
     if (this.options.addressManagerAddress) {
+      // const L1CrossDomainMessageFast
       const addressManager = getContractFactory('Lib_AddressManager')
         .connect(this.state.wallet)
         .attach(this.options.addressManagerAddress)
@@ -125,8 +186,8 @@ export class MessageRelayerService extends BaseServiceV2<
           StateCommitmentChain,
           CanonicalTransactionChain,
           BondManager,
-          OptimismPortal: '0x0000000000000000000000000000000000000000' as const,
-          L2OutputOracle: '0x0000000000000000000000000000000000000000' as const,
+          OptimismPortal: '0x0000000000000000000000000000000000000000' as const, // it should be used in bedrock
+          L2OutputOracle: '0x0000000000000000000000000000000000000000' as const, // it should be used in bedrock
         },
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,30 +553,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@defi-wonderland/smock@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/@defi-wonderland/smock/-/smock-2.0.2.tgz"
-  integrity sha512-nZtnUftPkMmFedqDzBqQrZWX+6Q3fK5MNMK3R6mLTg8Ig087A7ifs1KH9vGGpZ3p9RdgC+scUy9KfDASp2SKxg==
-  dependencies:
-    diff "^5.0.0"
-    lodash.isequal "^4.5.0"
-    lodash.isequalwith "^4.4.0"
-    rxjs "^7.2.0"
-    semver "^7.3.5"
-
-"@defi-wonderland/smock@^2.0.7":
-  version "2.0.7"
-  resolved "https://registry.npmjs.org/@defi-wonderland/smock/-/smock-2.0.7.tgz"
-  integrity sha512-RVpODLKZ/Cr0C1bCbhJ2aXbAr2Ll/K2WO7hDL96tqhMzCsA7ToWdDIgiNpV5Vtqqvpftu5ddO7v3TAurQNSU0w==
-  dependencies:
-    "@nomiclabs/ethereumjs-vm" "^4.2.2"
-    diff "^5.0.0"
-    lodash.isequal "^4.5.0"
-    lodash.isequalwith "^4.4.0"
-    rxjs "^7.2.0"
-    semver "^7.3.5"
-
-"@defi-wonderland/smock@^2.3.4":
+"@defi-wonderland/smock@^2.0.2", "@defi-wonderland/smock@^2.0.7":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@defi-wonderland/smock/-/smock-2.3.4.tgz#2bfe7e19052140634b25db344d77de9b0ac7a96b"
   integrity sha512-VYJbsoCOdFRyGkAwvaQhQRrU6V8AjK3five8xdbo41DEE9n3qXzUNBUxyD9HhXB/dWWPFWT21IGw5Ztl6Qw3Ew==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,6 +4402,11 @@ array-union@^3.0.1:
   resolved "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz"
   integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
 
+array-uniq@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
+
 array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz"
@@ -7970,7 +7975,7 @@ eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.8:
     idna-uts46-hx "^2.3.1"
     js-sha3 "^0.5.7"
 
-eth-gas-reporter@^0.2.20:
+eth-gas-reporter@^0.2.25:
   version "0.2.25"
   resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.25.tgz#546dfa946c1acee93cb1a94c2a1162292d6ff566"
   integrity sha512-1fRgyE4xUB8SoqLgN3eDfpDfwEfRxh2Sz1b7wzFbyQA+9TekMmvSjjoRu9SKcSVyK+vLkLIsVbJDsTWjw195OQ==


### PR DESCRIPTION
# Content

fast_relayer 서비스의 초기화 함수를 구현

- fast withdraw와 batch relay를 위한 옵션 추가
- CrossChainMessenger class 생성 시 L1CrossDomainMessengerFast 컨트랙트 객체 추가
- FAST_RELAYER 환경 변수 적용

# Test
log를 확인하여 초기화에서 fast_relayer 서비스의 옵션이 잘 세팅되었는지 체크

## docker

```bash
git checkout OR-460_make-initialization
yarn && yarn build
cd ops && docker-compose up -d
docker logs -f <CONTAINER_ID_MESSAGE_RELAYER_FAST>
docker logs -f <CONTAINER_ID_MESSAGE_RELAYER>

```
## native

```bash
# ongoing network...
cd packages/tokamak/message-relayer
cp .env.example .env
npm run start
```

# Jira Ticket
https://onther.atlassian.net/browse/OR-460