### PR TITLE
Or 959 support debug tracecall

### DIFF
--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -46,8 +46,10 @@ The state transitioning model does all the necessary work to work out a valid ne
 3) Create a new state object if the recipient is \0*32
 4) Value transfer
 == If contract creation ==
-  4a) Attempt to run transaction data
-  4b) If valid, use result as code for the new state object
+
+	4a) Attempt to run transaction data
+	4b) If valid, use result as code for the new state object
+
 == end ==
 5) Run Script section
 6) Derive new state root
@@ -84,6 +86,14 @@ type Message interface {
 	L1Timestamp() uint64
 	L1BlockNumber() *big.Int
 	QueueOrigin() types.QueueOrigin
+}
+
+// ExecutionResult includes all output after executing given evm
+// message no matter the execution itself is successful or not.
+type ExecutionResult struct {
+	UsedGas    uint64 // Total used gas but include the refunded gas
+	Err        error  // Any error encountered during the execution(listed in core/vm/errors.go)
+	ReturnData []byte // Returned data from evm(function result or data supplied with revert opcode)
 }
 
 // IntrinsicGas computes the 'intrinsic gas' for a message with the given data.

--- a/l2geth/eth/api_tracer.go
+++ b/l2geth/eth/api_tracer.go
@@ -63,6 +63,16 @@ type TraceConfig struct {
 	Reexec  *uint64
 }
 
+// TraceCallConfig is the config for traceCall API. It holds one more
+// field to override the state for tracing.
+type TraceCallConfig struct {
+	*vm.LogConfig
+	Tracer         *string
+	Timeout        *string
+	Reexec         *uint64
+	StateOverrides *ethapi.StateOverride
+}
+
 // StdTraceConfig holds extra parameters to standard-json trace functions.
 type StdTraceConfig struct {
 	vm.LogConfig
@@ -736,6 +746,62 @@ func (api *PrivateDebugAPI) TraceTransaction(ctx context.Context, hash common.Ha
 	}
 	// Trace the transaction and return
 	return api.traceTx(ctx, msg, vmctx, statedb, config)
+}
+
+// TraceCall lets you trace a given eth_call. It collects the structured logs
+// created during the execution of EVM if the given transaction was added on
+// top of the provided block and returns them as a JSON object.
+// You can provide -2 as a block number to trace on top of the pending block.
+func (api *PrivateDebugAPI) TraceCall(ctx context.Context, args ethapi.CallArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (interface{}, error) {
+	// Try to retrieve the specified block
+	var (
+		err   error
+		block *types.Block
+	)
+	// get block by hash or number
+	if hash, ok := blockNrOrHash.Hash(); ok {
+		block, err = api.eth.APIBackend.BlockByHash(ctx, hash)
+	} else if number, ok := blockNrOrHash.Number(); ok {
+		block, err = api.eth.APIBackend.BlockByNumber(ctx, number)
+	} else {
+		return nil, errors.New("invalid arguments; neither block nor hash specified")
+	}
+	if err != nil {
+		return nil, err
+	}
+	// try to recompute the state
+	reexec := defaultTraceReexec
+	if config != nil && config.Reexec != nil {
+		reexec = *config.Reexec
+	}
+	// retrieve state from certain block
+	statedb, err := api.computeStateDB(block, reexec)
+	if err != nil {
+		return nil, err
+	}
+	// Apply the customized state rules if required.
+	if config != nil {
+		if err := config.StateOverrides.Apply(statedb); err != nil {
+			return nil, err
+		}
+	}
+	// Execute the trace
+
+	// convert CallArg to Message
+	msg := args.ToMessage(api.eth.APIBackend.RPCGasCap().Uint64(), ctx, blockNrOrHash)
+	// creates a new context for use in the EVM.
+	vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
+
+	var traceConfig *TraceConfig
+	if config != nil {
+		traceConfig = &TraceConfig{
+			LogConfig: config.LogConfig,
+			Tracer:    config.Tracer,
+			Timeout:   config.Timeout,
+			Reexec:    config.Reexec,
+		}
+	}
+	return api.traceTx(ctx, msg, vmctx, statedb, traceConfig)
 }
 
 // traceTx configures a new tracer according to the provided configuration, and

--- a/l2geth/eth/api_tracer.go
+++ b/l2geth/eth/api_tracer.go
@@ -788,7 +788,7 @@ func (api *PrivateDebugAPI) TraceCall(ctx context.Context, args ethapi.CallArgs,
 	// Execute the trace
 
 	// convert CallArg to Message
-	msg := args.ToMessage(api.eth.APIBackend.RPCGasCap().Uint64(), ctx, blockNrOrHash)
+	msg := args.ToMessage(api.eth.APIBackend.RPCGasCap().Uint64(), block)
 	// creates a new context for use in the EVM.
 	vmctx := core.NewEVMContext(msg, block.Header(), api.eth.blockchain, nil)
 

--- a/l2geth/internal/web3ext/web3ext.go
+++ b/l2geth/internal/web3ext/web3ext.go
@@ -428,6 +428,12 @@ web3._extend({
 			inputFormatter: [null, null]
 		}),
 		new web3._extend.Method({
+			name: 'traceCall',
+			call: 'debug_traceCall',
+			params: 3,
+			inputFormatter: [null, null, null]
+		}),
+		new web3._extend.Method({
 			name: 'preimage',
 			call: 'debug_preimage',
 			params: 1,


### PR DESCRIPTION
Now we can support debug_traceCall RPC API
* You can see changes of the state and storage when a transaction is executed on a particular block.
* In detail, please refer to https://www.quicknode.com/docs/ethereum/debug_traceCall

## How to test
```bash
# checkout the branch
git checkout OR-959_support_debug_tracecall
cd ops
# start the network
docker-compose -f ./docker-compose.yml up -d

# wait for l2geth, and we use another terminal
# request debug_traceCall RPC method
curl http://localhost:8545 \
-X POST \
-H "Content-Type: application/json" \
--data '{"method":"debug_traceCall","params":[{"from":null,"to":"0x4200000000000000000000000000000000000007","data":"0xcbd4ece90000000000000000000000004200000000000000000000000000000000000010000000000000000000000000610178da211fef7d417bc0e6fed39f05609ad7880000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001500000000000000000000000000000000000000000000000000000000000000e4662a633a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000deaddeaddeaddeaddeaddeaddeaddeaddead0000000000000000000000000000dfc82d475833a50de90c642770f34a9db7deb725000000000000000000000000dfc82d475833a50de90c642770f34a9db7deb725000000000000000000000000000000000000000000000001158e460913d0000000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"}, "latest"],"id":1,"jsonrpc":"2.0"}'
```