### PR TITLE
Or 1096 bump the contracts

### DIFF
--- a/packages/tokamak/contracts/package.json
+++ b/packages/tokamak/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-network/titan-contracts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "L1 and L2 smart contracts for Titan",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/tokamak/message-relayer/package.json
+++ b/packages/tokamak/message-relayer/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "0.6.6",
-    "@tokamak-network/titan-contracts": "0.0.1",
+    "@tokamak-network/titan-contracts": "0.0.3",
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/ynatm": "^0.2.2",
     "@tokamak-network/titan-sdk": "0.0.6",

--- a/packages/tokamak/sdk/package.json
+++ b/packages/tokamak/sdk/package.json
@@ -49,7 +49,7 @@
     "mocha": "^10.0.0"
   },
   "dependencies": {
-    "@tokamak-network/titan-contracts": "0.0.1",
+    "@tokamak-network/titan-contracts": "0.0.3",
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/contracts-bedrock": "0.8.0",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3191,15 +3191,6 @@
     traverse "^0.6.6"
     unified "^9.2.2"
 
-"@tokamak-network/titan-contracts@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@tokamak-network/titan-contracts/-/titan-contracts-0.0.1.tgz#49f9932e6b6ed744ac36dcfe2f6deec251ab3e0a"
-  integrity sha512-/bd4gWHsu4RAMC0EsSHxYj+BFW6I3tskhcxMRKb669T+sklhtAjHOLLWCkCv81VKmuJ0mlrAKh5Y3yf406N9BA==
-  dependencies:
-    "@eth-optimism/core-utils" "0.10.1"
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/abstract-signer" "^5.7.0"
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"


### PR DESCRIPTION
I found the missing of contract file in published packages (version 0.0.2, https://www.npmjs.com/package/@tokamak-network/titan-contracts/v/0.0.2?activeTab=code )
* bump version for re-publishing the package: 0.0.2 → 0.0.3