### PR TITLE
Or 1098 fix missing contracts file

### DIFF
--- a/.github/workflows/titan-packages-release.yml
+++ b/.github/workflows/titan-packages-release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build
+        run: yarn build
+
       - name: Create .npmrc
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > .npmrc

--- a/packages/tokamak/contracts/package.json
+++ b/packages/tokamak/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-network/titan-contracts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "L1 and L2 smart contracts for Titan",
   "main": "dist/index",
   "types": "dist/index",

--- a/packages/tokamak/message-relayer/package.json
+++ b/packages/tokamak/message-relayer/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@eth-optimism/common-ts": "0.6.6",
-    "@tokamak-network/titan-contracts": "0.0.3",
+    "@tokamak-network/titan-contracts": "0.0.4",
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/ynatm": "^0.2.2",
     "@tokamak-network/titan-sdk": "0.0.6",

--- a/packages/tokamak/sdk/package.json
+++ b/packages/tokamak/sdk/package.json
@@ -49,7 +49,7 @@
     "mocha": "^10.0.0"
   },
   "dependencies": {
-    "@tokamak-network/titan-contracts": "0.0.3",
+    "@tokamak-network/titan-contracts": "0.0.4",
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/contracts-bedrock": "0.8.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Problem: missing built files in the published npm packages

* add build job in the github action script
* bump version of titan-contracts: 0.0.3 -> 0.0.4

published npm package: https://www.npmjs.com/package/@tokamak-network/titan-contracts/v/0.0.4?activeTab=code