### PR TITLE
bump version

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -33,7 +33,7 @@
     "@eth-optimism/contracts-periphery": "^1.0.1",
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/sdk": "1.6.6",
-    "@tokamak-network/titan-sdk": "0.0.6",
+    "@tokamak-network/titan-sdk": "0.0.7",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@ethersproject/transactions": "^5.7.0",

--- a/packages/tokamak/message-relayer/package.json
+++ b/packages/tokamak/message-relayer/package.json
@@ -35,7 +35,7 @@
     "@tokamak-network/titan-contracts": "0.0.4",
     "@eth-optimism/core-utils": "0.10.1",
     "@eth-optimism/ynatm": "^0.2.2",
-    "@tokamak-network/titan-sdk": "0.0.6",
+    "@tokamak-network/titan-sdk": "0.0.7",
     "ethers": "^5.7.0"
   },
   "devDependencies": {

--- a/packages/tokamak/sdk/package.json
+++ b/packages/tokamak/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-network/titan-sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "[Tokamak-Titan] Tools for working with Titan",
   "main": "dist/index",
   "types": "dist/index",


### PR DESCRIPTION
To fix the missing file in published npm package.
* @tokamak-network/titan-sdk: 0.0.6 -> 0.0.7